### PR TITLE
Apply PUID:PGID to files at time of download completion. #13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN addgroup --gid "$PGID" abc && \
         --disabled-password \
         --no-create-home \
         --uid "$PUID" \
-        --ingroup abc \
-        --shell abc \
+        --ingroup abc, root \
+        --shell /bin/bash \
         abc 
 
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,11 @@ RUN apk update && \
 RUN addgroup --gid "$PGID" abc && \
     adduser \
         --gecos "" \
+        --system \
         --disabled-password \
         --no-create-home \
         --uid "$PUID" \
-        --ingroup abc root \
+        --ingroup abc \
         --shell /bin/bash \
         abc 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN addgroup --gid "$PGID" abc && \
         --disabled-password \
         --no-create-home \
         --uid "$PUID" \
-        --ingroup abc, root \
+        --ingroup abc root \
         --shell /bin/bash \
         abc 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN addgroup --gid "$PGID" abc && \
         --disabled-password \
         --no-create-home \
         --uid "$PUID" \
-        --ingroup root \
+        --ingroup abc \
         --shell /bin/bash \
         abc 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,10 @@ RUN apk update && \
 RUN addgroup --gid "$PGID" abc && \
     adduser \
         --gecos "" \
-        --system \
         --disabled-password \
         --no-create-home \
         --uid "$PUID" \
-        --ingroup abc \
+        --ingroup root \
         --shell /bin/bash \
         abc 
 

--- a/root/app/youtube-dl/updater.sh
+++ b/root/app/youtube-dl/updater.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/with-contenv bash
 
-apk update > /dev/null && apk upgrade > /dev/null
-python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
+#apk update > /dev/null && apk upgrade > /dev/null
+#python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
+apk update > /dev/null && apk upgrade
+python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl
 
 sleep 60m

--- a/root/app/youtube-dl/updater.sh
+++ b/root/app/youtube-dl/updater.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bash
+
+apk update > /dev/null && apk upgrade > /dev/null
+python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
+
+sleep 60m

--- a/root/app/youtube-dl/updater.sh
+++ b/root/app/youtube-dl/updater.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-#apk update > /dev/null && apk upgrade > /dev/null
-#python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
-apk update && apk upgrade
-python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl
+apk update > /dev/null && apk upgrade > /dev/null
+python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
 
-sleep 60m
+sleep 3h

--- a/root/app/youtube-dl/updater.sh
+++ b/root/app/youtube-dl/updater.sh
@@ -2,7 +2,7 @@
 
 #apk update > /dev/null && apk upgrade > /dev/null
 #python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
-apk update > /dev/null && apk upgrade
+apk update && apk upgrade
 python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl
 
 sleep 60m

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/with-contenv bash
 
 echo "UPDATING"
-apk update > /dev/null && apk upgrade > /dev/null
-python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
+sudo apk update > /dev/null && apk upgrade > /dev/null
+sudo python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
 echo "UPDATING OVER"
 
 if grep -qe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-echo "UPDATING"
-apk update > /dev/null && apk upgrade > /dev/null
-python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
-echo "UPDATING OVER"
-
 if grep -qe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
 if grep -qe '--dateafter ' "/config/args.conf"; then youtubedl_args_dateafter=true; else youtubedl_args_dateafter=false; fi
 if grep -qe '--download-archive ' "/config/args.conf"; then youtubedl_args_downloadarchive=true; else youtubedl_args_downloadarchive=false; fi

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/with-contenv bash
 
 echo "UPDATING"
-sudo apk update > /dev/null && apk upgrade > /dev/null
-sudo python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
+apk update > /dev/null && apk upgrade > /dev/null
+python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
 echo "UPDATING OVER"
 
 if grep -qe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/with-contenv bash
 
+echo "UPDATING"
 apk update > /dev/null && apk upgrade > /dev/null
 python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
+echo "UPDATING OVER"
 
 if grep -qe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
 if grep -qe '--dateafter ' "/config/args.conf"; then youtubedl_args_dateafter=true; else youtubedl_args_dateafter=false; fi

--- a/root/etc/cont-init.d/10-user-permissions
+++ b/root/etc/cont-init.d/10-user-permissions
@@ -7,4 +7,5 @@ chown -R abc:abc /app/youtube-dl
 chown -R abc:abc /config
 chown -R abc:abc /downloads
 
+chmod +x /app/youtube-dl/updater.sh
 chmod +x /app/youtube-dl/youtube-dl.sh

--- a/root/etc/services.d/updater/run
+++ b/root/etc/services.d/updater/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
 
-exec s6-envuidgid /app/youtube-dl/updater.sh
+exec s6-envuidgid root /app/youtube-dl/updater.sh

--- a/root/etc/services.d/updater/run
+++ b/root/etc/services.d/updater/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bash
+
+exec s6-setuidgid root /app/youtube-dl/updater.sh

--- a/root/etc/services.d/updater/run
+++ b/root/etc/services.d/updater/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
 
-exec /app/youtube-dl/updater.sh
+exec s6-envuidgid /app/youtube-dl/updater.sh

--- a/root/etc/services.d/updater/run
+++ b/root/etc/services.d/updater/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
 
-exec s6-setuidgid root /app/youtube-dl/updater.sh
+exec /app/youtube-dl/updater.sh

--- a/root/etc/services.d/youtube-dl/run
+++ b/root/etc/services.d/youtube-dl/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
 
-exec s6-envuidgid -B abc /app/youtube-dl/youtube-dl.sh
+exec s6-setuidgid abc /app/youtube-dl/youtube-dl.sh


### PR DESCRIPTION
Container now correctly uses PUID and PGID provided by the user.

Closes #13 