### PR TITLE
Issue: Atomicpasrley error #27

### DIFF
--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-alias AtomicParsley=atomicparsley
-
 if $youtubedl_debug; then youtubedl_args_verbose=true; else youtubedl_args_verbose=false; fi
 if grep -qe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
 if grep -qe '--download-archive ' "/config/args.conf"; then youtubedl_args_downloadarchive=true; else youtubedl_args_downloadarchive=false; fi

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/with-contenv bash
 
+alias AtomicParsley=atomicparsley
+
 if $youtubedl_debug; then youtubedl_args_verbose=true; else youtubedl_args_verbose=false; fi
 if grep -qe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
 if grep -qe '--download-archive ' "/config/args.conf"; then youtubedl_args_downloadarchive=true; else youtubedl_args_downloadarchive=false; fi

--- a/root/etc/cont-init.d/15-fix-atomicparsley
+++ b/root/etc/cont-init.d/15-fix-atomicparsley
@@ -1,0 +1,7 @@
+if ! [ -f "/usr/bin/AtomicParsley" ]
+then
+  if [ -f "/usr/bin/atomicparsley" ]
+  then
+    ln /usr/bin/atomicparsley /usr/bin/AtomicParsley
+  fi
+fi

--- a/root/etc/cont-init.d/15-fix-atomicparsley
+++ b/root/etc/cont-init.d/15-fix-atomicparsley
@@ -1,3 +1,5 @@
+#!/usr/bin/with-contenv bash
+
 if ! [ -f "/usr/bin/AtomicParsley" ]
 then
   if [ -f "/usr/bin/atomicparsley" ]


### PR DESCRIPTION
The binary is no longer named 'AtomicParsley', for whatever reason it's been changed to 'atomicparsley'.
Which meant youtube-dl couldn't use AtomicParsley.