### PR TITLE
Relocate default '--format'

### DIFF
--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -8,7 +8,6 @@ youtubedl_binary="youtube-dl"
 exec=$youtubedl_binary
 if $youtubedl_args_verbose; then exec+=" --verbose"; fi
 if ! $youtubedl_args_downloadarchive; then exec+=" --download-archive /config/archive.txt"; fi
-if [ -f '/config/dateafter.txt' ]; then exec+=" --dateafter $(cat "/config/dateafter.txt")"; fi
 exec+=" --config-location /config/args.conf"
 exec+=" --batch-file /config/channels.txt"
 

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -1,38 +1,23 @@
 #!/usr/bin/with-contenv bash
 
 if $youtubedl_debug; then youtubedl_args_verbose=true; else youtubedl_args_verbose=false; fi
-if grep -qe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
-if grep -qe '--download-archive ' "/config/args.conf"; then youtubedl_args_downloadarchive=true; else youtubedl_args_downloadarchive=false; fi
-
-if ! [ -f "/config/archive.txt" ]
-then
-  if ! $youtubedl_args_downloadarchive
-  then
-    echo "'--download-archive' not defined in args."
-    echo "creating and using 'archive.txt'."
-    touch "/config/archive.txt"
-  fi
-fi
+if grep -qiEe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
+if grep -qiEe '--download-archive ' "/config/args.conf"; then youtubedl_args_downloadarchive=true; else youtubedl_args_downloadarchive=false; fi
 
 youtubedl_binary="youtube-dl"
 exec=$youtubedl_binary
 if $youtubedl_args_verbose; then exec+=" --verbose"; fi
-if ! $youtubedl_args_downloadarchive; then exec+=" --download-archive "/config/archive.txt""; fi
-if [ -f "/config/dateafter.txt" ]; then exec+=" --dateafter $(cat /config/dateafter.txt)"; fi
-exec+=" --config-location "/config/args.conf""
-exec+=" --batch-file "/config/channels.txt""
+if ! $youtubedl_args_downloadarchive; then exec+=" --download-archive /config/archive.txt"; fi
+if [ -f '/config/dateafter.txt' ]; then exec+=" --dateafter $(cat "/config/dateafter.txt")"; fi
+exec+=" --config-location /config/args.conf"
+exec+=" --batch-file /config/channels.txt"
 
-while ! [ -f /usr/bin/$youtubedl_binary ]; do sleep 1s; done
+while ! [ -f "$(which $youtubedl_binary)" ]; do sleep 1s; done
 sed -i -E 's!  *$!!; s!//*$!!; s!(youtube.*(channel|user|c))/([^/]+$)!\1/\3/videos!i' /config/channels.txt
 youtubedl_version=$($youtubedl_binary --version)
 youtubedl_last_run_time=$(date "+%s")
 
-if ! $youtubedl_args_format
-then
-  $exec --format "bestvideo[height<=$youtubedl_quality][vcodec=vp9][fps>30]+bestaudio[acodec!=opus] / bestvideo[height<=$youtubedl_quality][vcodec=vp9]+bestaudio[acodec!=opus] / bestvideo[height<=$youtubedl_quality]+bestaudio[acodec!=opus] / best"
-else
-  $exec
-fi
+if $youtubedl_args_format; then $exec; else $exec --format "$(cat '/config.default/format')"; fi
 
 if [ $(( ($(date "+%s") - $youtubedl_last_run_time) / 60 )) -ge 2 ]
 then

--- a/root/config.default/format
+++ b/root/config.default/format
@@ -1,0 +1,1 @@
+bestvideo[height<=$youtubedl_quality][vcodec=vp9][fps>30]+bestaudio[acodec!=opus]/bestvideo[height<=$youtubedl_quality][vcodec=vp9]+bestaudio[acodec!=opus]/bestvideo[height<=$youtubedl_quality]+bestaudio[acodec!=opus]/best

--- a/root/etc/cont-init.d/05-default-confs
+++ b/root/etc/cont-init.d/05-default-confs
@@ -10,3 +10,5 @@ then
   echo "[default-confs] restoring default 'channels.txt'."
   cp /config.default/channels.txt /config/
 fi
+
+sed -i -E 's!\$youtubedl_quality!'"${youtubedl_quality}"'!g' /config.default/format


### PR DESCRIPTION
* `root/app/youtube-dl/youtube-dl.sh`
  * Removed default `--format` parameter.
  * Removed support for `/config/dateafter.txt` file.
    Use `--dateafter` inside your `args.conf` instead.
  * Minor cleanup.
* `root/config.default/format`
  * NEW
    Contains the default `--format` parameter.
* `root/etc/cont-init.d/05-default-confs`
  * Applies ENV `youtubedl_quality`.
    At startup, modifies `root/config.default/format` with the value from ENV `youtubedl_quality`. 