### PR TITLE
Only delete /etc/services.d/webserver if exists

### DIFF
--- a/root/etc/cont-init.d/80-webui
+++ b/root/etc/cont-init.d/80-webui
@@ -5,5 +5,5 @@ then
   echo "[web-ui] webserver is enabled."
 else
   echo "[web-ui] webserver is disabled."
-  [ -f '/etc/services.d/webserver' ] && rm -r /etc/services.d/webserver
+  rm -rf /etc/services.d/webserver
 fi

--- a/root/etc/cont-init.d/80-webui
+++ b/root/etc/cont-init.d/80-webui
@@ -5,5 +5,5 @@ then
   echo "[web-ui] webserver is enabled."
 else
   echo "[web-ui] webserver is disabled."
-  [ ! -f '/etc/services.d/webserver' ] && rm -r /etc/services.d/webserver
+  [ -f '/etc/services.d/webserver' ] && rm -r /etc/services.d/webserver
 fi

--- a/root/etc/cont-init.d/80-webui
+++ b/root/etc/cont-init.d/80-webui
@@ -5,5 +5,5 @@ then
   echo "[web-ui] webserver is enabled."
 else
   echo "[web-ui] webserver is disabled."
-  rm -r /etc/services.d/webserver
+  [ ! -f '/etc/services.d/webserver' ] && rm -r /etc/services.d/webserver
 fi


### PR DESCRIPTION
Another option is to use `rf -rf /etc/services.d/webserver` since the `f` flag ignores missing files

Was fataling with:  

```
[cont-init.d] 80-webui: executing...
[web-ui] webserver is disabled.
rm: cannot remove '/etc/services.d/webserver': No such file or directory
[cont-init.d] 80-webui: exited 1.
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
```

Tested with a locally built image