### PR TITLE
Change from youtube-dl to yt-dlp, adjusted auto-updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN set -x && \
 RUN set -x && \
     wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/bin/yt-dlp
 
+RUN set -x && \
+    chmod a+x /usr/bin/yt-dlp
+
 VOLUME /config /downloads
 
 WORKDIR /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN set -x && \
     python3 -m pip --no-cache-dir install -r /app/requirements.txt
 
 RUN set -x && \
-    python3 -m pip --no-cache-dir install youtube_dl
+    wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/bin/yt-dlp
 
 VOLUME /config /downloads
 

--- a/root/app/youtube-dl/updater.sh
+++ b/root/app/youtube-dl/updater.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/with-contenv bash
 
 apk upgrade --no-cache > /dev/null
-python3 -m pip --no-cache-dir --disable-pip-version-check install --upgrade youtube_dl > /dev/null
+#update yt-dlp
+/usr/bin/yt-dlp -U
 sleep 3h

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -4,7 +4,7 @@ if $youtubedl_debug; then youtubedl_args_verbose=true; else youtubedl_args_verbo
 if grep -qiEe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
 if grep -qiEe '--download-archive ' "/config/args.conf"; then youtubedl_args_downloadarchive=true; else youtubedl_args_downloadarchive=false; fi
 
-youtubedl_binary="youtube-dl"
+youtubedl_binary="yt-dlp"
 exec=$youtubedl_binary
 if $youtubedl_args_verbose; then exec+=" --verbose"; fi
 if ! $youtubedl_args_downloadarchive; then exec+=" --download-archive /config/archive.txt"; fi


### PR DESCRIPTION
This changes the dockerfile to pull in latest yt-dlp binary, adjusts youtube-dl.sh, and updater.sh for use with yt-dlp, which is currently better maintained.