### PR TITLE
Added aarch64/arm64 compatibility. Updated readme to yt-dlp added known breakers. Updated build automation to add multiarch images.

### DIFF
--- a/.github/workflows/push-new-image.yml
+++ b/.github/workflows/push-new-image.yml
@@ -57,5 +57,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.IMAGE_REPO }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,23 @@ RUN printf "\
 http://dl-cdn.alpinelinux.org/alpine/edge/testing\n\
 " >> /etc/apk/repositories
 
-RUN wget -P /tmp/ https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-amd64.tar.gz && \
-    tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
-    rm -rf /tmp/* 
+RUN /bin/ash -c 'set -ex && \
+    ARCH=`uname -m` && \
+    if [ "$ARCH" == "x86_64" ]; then \
+       echo "Architecture = x86_64" && \
+       wget -P /tmp/ https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-amd64.tar.gz && \
+       tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
+       rm -rf /tmp/* ; \
+    elif [ "$ARCH" == "aarch64" ]; then \
+       echo "Architecture = aarch64" && \
+       wget -P /tmp/ https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-aarch64.tar.gz && \
+       tar xzf /tmp/s6-overlay-aarch64.tar.gz -C / && \
+       rm -rf /tmp/* ; \
+    else \
+       echo "unknown arch" && \
+       exit 1 \
+    fi'
+
 
 RUN addgroup --gid "$PGID" abc && \
     adduser \

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/jeeaaasustest/youtube-dl?style=flat&logo=docker)](https://hub.docker.com/r/jeeaaasustest/youtube-dl/)
 [![Docker Stars](https://img.shields.io/docker/stars/jeeaaasustest/youtube-dl?style=flat&logo=docker)](https://hub.docker.com/r/jeeaaasustest/youtube-dl/)
 
-**Automated youtube-dl Docker image for downloading YouTube subscriptions**
+**Automated yt-dlp Docker image for downloading YouTube subscriptions**
 
 Docker hub page [here](https://hub.docker.com/r/jeeaaasustest/youtube-dl).  
-youtube-dl documentation [here](https://github.com/ytdl-org/youtube-dl/blob/master/README.md#readme).
+yt-dlp documentation [here](https://github.com/yt-dlp/yt-dlp).
 
 # Features
 * **Easy Usage with Minimal Setup**
@@ -21,7 +21,7 @@ youtube-dl documentation [here](https://github.com/ytdl-org/youtube-dl/blob/mast
     * Interval options with env parameter
     * Channel URLs from file
 * **PUID/PGID**
-* **youtube-dl Options**
+* **yt-dlp Options**
     * Format
     * Quality
     * High fps videos
@@ -67,6 +67,7 @@ Then configure the channels as explained in the [Configure youtube-dl](https://g
 | `youtubedl_webuiport` | (`8080`) | If you want to change the default web-ui port.
 | `youtubedl_interval` | `1h` (`3h`) `12h` `3d` | If you want to change the default download interval. 1 hour, (3 hours), 12 hours, 3 days.
 | `youtubedl_quality` | `720` (`1080`) `1440` `2160` | If you want to change the default download resolution. 720p, (1080p), 1440p, 4k.
+  `youtubedl_completed` | `true` (`false`) | Used to add a youtubedl-complete file in downloads directory.  Useful trigger for external cron jobs/file movers.
 
 # Image Tags
 * **`latest`**
@@ -120,4 +121,4 @@ Then configure the channels as explained in the [Configure youtube-dl](https://g
     
     Don't want mp4 files? Change the line with `--merge-output-format` to suit your needs.
 
-    youtube-dl configuration options documentation [here](https://github.com/ytdl-org/youtube-dl/blob/master/README.md#options).
+    yt-dlp configuration options documentation [here](https://github.com/yt-dlp/yt-dlp#usage-and-options).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Then configure the channels as explained in the [Configure youtube-dl](https://g
 | `youtubedl_webuiport` | (`8080`) | If you want to change the default web-ui port.
 | `youtubedl_interval` | `1h` (`3h`) `12h` `3d` | If you want to change the default download interval. 1 hour, (3 hours), 12 hours, 3 days.
 | `youtubedl_quality` | `720` (`1080`) `1440` `2160` | If you want to change the default download resolution. 720p, (1080p), 1440p, 4k.
-  `youtubedl_completed` | `true` (`false`) | Used to add a youtubedl-complete file in downloads directory.  Useful trigger for external cron jobs/file movers.
+  `youtubedl_completed` | `true` (`false`) | Used to add a youtubedl-completed file in downloads directory.  Useful trigger for external cron jobs/file movers.
 
 # Image Tags
 * **`latest`**
@@ -121,6 +121,6 @@ Then configure the channels as explained in the [Configure youtube-dl](https://g
     
     Don't want mp4 files? Change the line with `--merge-output-format` to suit your needs.
 
-    If using `%(playlist_index)` in output format and `--playlist-reverse`, the change from youtube-dl to ytp-dl alters how this operates.  Recommendation is to move to `%(playlist_autonumber)` and using `--compat-options playlist-index` instead.  More details [here] (https://github.com/yt-dlp/yt-dlp/pull/302).
+    If using `%(playlist_index)` in output format and `--playlist-reverse`, the change from youtube-dl to ytp-dl alters how this operates.  Recommendation is to move to `%(playlist_autonumber)` and using `--compat-options playlist-index` instead.  More details [here](https://github.com/yt-dlp/yt-dlp/pull/302).
 
     yt-dlp configuration options documentation [here](https://github.com/yt-dlp/yt-dlp#usage-and-options).

--- a/README.md
+++ b/README.md
@@ -121,4 +121,6 @@ Then configure the channels as explained in the [Configure youtube-dl](https://g
     
     Don't want mp4 files? Change the line with `--merge-output-format` to suit your needs.
 
+    If using `%(playlist_index)` in output format and `--playlist-reverse`, the change from youtube-dl to ytp-dl alters how this operates.  Recommendation is to move to `%(playlist_autonumber)` and using `--compat-options playlist-index` instead.  More details [here] (https://github.com/yt-dlp/yt-dlp/pull/302).
+
     yt-dlp configuration options documentation [here](https://github.com/yt-dlp/yt-dlp#usage-and-options).

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -4,6 +4,11 @@ if $youtubedl_debug; then youtubedl_args_verbose=true; else youtubedl_args_verbo
 if grep -qiEe '--format ' "/config/args.conf"; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
 if grep -qiEe '--download-archive ' "/config/args.conf"; then youtubedl_args_downloadarchive=true; else youtubedl_args_downloadarchive=false; fi
 
+if $youtubedl_completed && [ -f '/downloads/youtubedl-completed' ]
+then
+  rm '/downloads/youtubedl-completed'
+fi
+
 youtubedl_binary="yt-dlp"
 exec=$youtubedl_binary
 if $youtubedl_args_verbose; then exec+=" --verbose"; fi
@@ -23,6 +28,11 @@ then
   echo "$(date "+%Y-%m-%d %H:%M:%S") - execution took $(( ($(date "+%s") - $youtubedl_last_run_time) / 60 )) minutes"
 else
   echo "$(date "+%Y-%m-%d %H:%M:%S") - execution took $(( ($(date "+%s") - $youtubedl_last_run_time) )) seconds"
+fi
+
+if $youtubedl_completed
+then
+  touch '/downloads/youtubedl-completed'
 fi
 
 echo "youtube-dl version: $youtubedl_version"


### PR DESCRIPTION
Lots of changes here.

- Added condition for s6 overlay to split x64 and aarch64 tars without duplicate dockerfiles
- added platforms to build action
- updated readme to yt-dlp references
- added caveat around playlist_index and autonumbering
- added youtube_completed env and actions in script to touch a file in the downloads directory upon completion and remove on start.  This can allow for external cron jobs and file movers to know that the script is not running at that time.  There's additional functionality and testing to be completed here, but it's a start to move something I was doing externally directly into the script.

Thanks!