### PR TITLE
Change base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM debian:11-slim
 
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS="2" \
     PUID="911" \
@@ -12,21 +12,8 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS="2" \
     youtubedl_interval="3h" \
     youtubedl_quality="1080" 
 
-RUN set -ex && \
-    ARCH=`uname -m` && \
-    if [ "$ARCH" == "x86_64" ]; then \
-        s6_package="s6-overlay-amd64.tar.gz" ; \
-    elif [ "$ARCH" == "aarch64" ]; then \
-        s6_package="s6-overlay-aarch64.tar.gz" ; \
-    else \
-        echo "unknown arch" && \
-        exit 1 ; \
-    fi && \
-    wget -P /tmp/ https://github.com/just-containers/s6-overlay/releases/latest/download/${s6_package} && \
-    tar xzf /tmp/${s6_package} -C / && \
-    rm -rf /tmp/*
-
-RUN addgroup --gid "$PGID" abc && \
+RUN set -x && \
+    addgroup --gid "$PGID" abc && \
     adduser \
         --gecos "" \
         --disabled-password \
@@ -39,20 +26,37 @@ RUN addgroup --gid "$PGID" abc && \
 COPY root/ /
 
 RUN set -x && \
-    apk upgrade --no-cache && \
-    apk add --no-cache \
-        bash \
-        coreutils \
-        shadow \
-        tzdata \
+    apt update && \
+    apt install -y \
+        wget \
         python3 \
-        py3-pip \
-        ffmpeg && \
+        python3-pip && \
+    apt clean && \
     python3 -m pip --no-cache-dir install -r /app/requirements.txt && \
     rm -rf \
-        /app/requirements.txt \
-        /root/.cache \
-        /root/packages
+        /var/lib/apt/lists/* \
+        -rf /tmp/* \
+        /app/requirements.txt
+
+RUN set -x && \
+    wget -q $(wget -q https://api.github.com/repos/nihil-admirari/FFmpeg-With-VP9-Timestamp-Fix/releases/latest -O - | grep -ioE 'https://github.com/nihil-admirari/FFmpeg-With-VP9-Timestamp-Fix/releases/download/.*?-linux64-nonfree.tar.xz') -O - | tar -xJ -C /tmp/ && \
+    chmod -R a+x $(find /tmp/ffmpeg*/bin/ -type d) && \
+    mv $(find /tmp/ffmpeg*/bin/ -type d)/* /usr/bin/ && \
+    rm -rf /tmp/*
+
+RUN set -ex && \
+    ARCH=`uname -m` && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        s6_package="s6-overlay-amd64.tar.gz" ; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        s6_package="s6-overlay-aarch64.tar.gz" ; \
+    else \
+        echo "unknown arch: ${ARCH}" && \
+        exit 1 ; \
+    fi && \
+    wget -P /tmp/ https://github.com/just-containers/s6-overlay/releases/latest/download/${s6_package} && \
+    tar -xzf /tmp/${s6_package} -C / && \
+    rm -rf /tmp/*
 
 RUN set -x && \
     wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/bin/yt-dlp && \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Image tags `latest`, `v2021.09.02` and future `v<VERSION>` now contains [yt-dlp]
 
 There are many new and changed default arguments, if you have modified your `args.conf` you might want to take a look at the new [default args](https://github.com/Jeeaaasus/youtube-dl/blob/master/root/config.default/args.conf). If you have not modified your `args.conf` it should update to the new one.  
 
-With yt-dlp comes many improvments, such as, bypass age gate in most cases, better video format selection, [SponsorBlock API](https://sponsor.ajay.app/) support to generate chapters when there are sponsored segments, although cutting out segments are not yet supported.  
+With yt-dlp comes many improvments, such as, bypass age gate in most cases, better video format selection, [SponsorBlock API](https://sponsor.ajay.app/) support to generate chapters when there are sponsored segments, <s>although cutting out segments are not yet supported</s> ***(fixed)***.  
 Other new stuff include, arm64 image, new ENVs: `youtubedl_lockfile`, to help with external scripts. `youtubedl_cookies`, an easy way to pass cookies without the need to modify your `args.conf`. `youtubedl_watchlater`, an easy way to download your Watch Later playlist.
 #
 
@@ -40,7 +40,7 @@ Hopefully this wont affect most users but if you are someone with a heavily cust
     * Channel URLs from file
 * **PUID/PGID**
 * **yt-dlp Options**
-   * SponsorBlock*
+   * SponsorBlock
    * Format
    * Quality
    * High fps videos
@@ -139,7 +139,6 @@ Then configure the channels as explained in the [Configure youtube-dl](https://g
     **Unsupported arguments**
     * `--config-location`, hardcoded to `/config/args.conf`.
     * `--batch-file`, hardcoded to `/config/channels.txt`.
-    * `--sponsorblock-remove`, currently unsupported because of a bug with ffmpeg.
 
     **Default arguments**
     * `--output "/downloads/%(uploader)s/%(title)s.%(ext)s"`, makes youtube-dl create separate folders for each channel and use the video title for the filename.

--- a/root/app/youtube-dl/updater.sh
+++ b/root/app/youtube-dl/updater.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv bash
 
-apk upgrade --no-cache > /dev/null
 yt-dlp -U > /dev/null
 sleep 3h


### PR DESCRIPTION
* Change base image to Debian.
  * The musl c library Alpine uses is causing issues.
* Use patched ffmpeg (Thanks to [@nihil-admirari](https://github.com/nihil-admirari/FFmpeg-With-VP9-Timestamp-Fix)) that works correctly with VP9 videos.
  * Fixes `--sponsorblock-remove`, Closes #52.