### PR TITLE
WebUI: Mark the web ui port 8080 as exposed in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,6 @@ VOLUME /config /downloads
 
 WORKDIR /config
 
+EXPOSE 8080/tcp
+
 ENTRYPOINT ["/init"]


### PR DESCRIPTION
Some Docker applications would benefit from having the `EXPOSED` declaration, for example [nginx-proxy/docker-gen](https://github.com/nginx-proxy/docker-gen) and [nginx-proxy/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy).

The `EXPOSED` declaration itself has no influence on the functionality of the docker container, as explained in the official [Dockerfile reference](https://docs.docker.com/engine/reference/builder/#expose) for `EXPOSED`:

The ´EXPOSE´ instruction informs Docker that the container listens on the specified network ports at runtime. You can specify whether the port listens on TCP or UDP, and the default is TCP if the protocol is not specified.

The ´EXPOSE´ instruction does not actually publish the port. It functions as a type of documentation between the person who builds the image and the person who runs the container, about which ports are intended to be published. To actually publish the port when running the container, use the ´-p´ flag on ´docker run´ to publish and map one or more ports, or the ´-P´ flag to publish all exposed ports and map them to high-order ports.