### PR TITLE
Update README.md - add detail about interval arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Then configure the channels as explained in the [Configure youtube-dl](https://g
 | `youtubedl_cookies` | `true` (`false`) | Used to pass cookies for authentication.
 | `youtubedl_subscriptions` | `true` (`false`) | If you want to download all your subscriptions. Authentication is required.
 | `youtubedl_watchlater` | `true` (`false`) | If you want to download your Watch Later playlist. Authentication is required.
-| `youtubedl_interval` | `1h` (`3h`) `12h` `3d` | If you want to change the default download interval.<br>1 hour, (3 hours), 12 hours, 3 days.
+| `youtubedl_interval` | `1h` (`3h`) `12h` `3d` | If you want to change the default download interval. This can be any argument compatible with [gnu sleep](https://github.com/tldr-pages/tldr/blob/main/pages/linux/sleep.md).  Be mindful that if you download too frequently, you risk getting ip-banned by YouTube.<br />1 hour, (3 hours), 12 hours, 3 days.
 | `youtubedl_quality` | `720` (`1080`) `1440` `2160` | If you want to change the default download resolution.<br>720p, (1080p), 1440p, 4k.
 
 # Image Tags


### PR DESCRIPTION
My use case is manually dropping urls into `channels.txt` and having them download immediately.

I fiddled around and realised I can pass any interval argument to `sleep`, per https://github.com/Jeeaaasus/youtube-dl/blob/master/root/app/youtube-dl/youtube-dl.sh#L55. I set the interval to be very brief so that the URLs get picked up and downloaded straight away, and it seems to work great.

I thought I'd document it in case someone else has the same idea. Thanks for the great util!

