### PR TITLE
Fix PEP 668 error on Debian 12: use venv paths for pip/yt-dlp

### DIFF
--- a/root/app/youtube-dl/updater.sh
+++ b/root/app/youtube-dl/updater.sh
@@ -3,7 +3,7 @@
 while true; do
   touch '/tmp/updater-running'
   sleep 10s
-  pip --no-cache-dir --quiet install --upgrade yt-dlp[default] > /dev/null
+  /home/abc/.venv/bin/pip --no-cache-dir --quiet install --upgrade yt-dlp[default] > /dev/null
   rm -f '/tmp/updater-running'
   sleep 3h
 done

--- a/root/app/youtube-dl/youtube-dl.sh
+++ b/root/app/youtube-dl/youtube-dl.sh
@@ -5,7 +5,7 @@ if grep -qPe '^(--output |-o ).*\$\(' '/config/args.conf'; then youtubedl_args_o
 if grep -qPe '^(--format |-f )' '/config/args.conf'; then youtubedl_args_format=true; else youtubedl_args_format=false; fi
 if grep -qPe '^--download-archive ' '/config/args.conf'; then youtubedl_args_download_archive=true; else youtubedl_args_download_archive=false; fi
 
-youtubedl_binary='yt-dlp'
+youtubedl_binary='/home/abc/.venv/bin/yt-dlp'
 exec="$youtubedl_binary"
 exec+=" --config-location '/config/args.conf'"
 exec+=" --batch-file '/tmp/urls'"; (cat '/config/channels.txt'; echo '') > '/tmp/urls.temp'


### PR DESCRIPTION
## Problem
On Debian 12, `pip` and `yt-dlp` fail at runtime:
- `pip`: blocked by PEP 668 (externally-managed-environment)
- `yt-dlp`: command not found (supervisor doesn't inherit Docker ENV PATH)

## Fix
Use absolute paths to the venv binaries that the Dockerfile already creates:
- `/home/abc/.venv/bin/pip` in `updater.sh`
- `/home/abc/.venv/bin/yt-dlp` in `youtube-dl.sh`